### PR TITLE
Fix [NginX]: Fixing Nginx query params parsing error

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -40,9 +40,9 @@ http {
           }
 
           location /exp {
-               set $original_url http://exp-service:5050$request_uri;
+               set $original_url http://exp-service:5050$uri;
 
-               proxy_pass http://proxy-service/proxy?to=$original_url;
+               proxy_pass http://proxy-service/proxy?to=$original_url&$args;
 
                proxy_set_header Host $host;
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -50,9 +50,9 @@ http {
           }
 
           location /task {
-               set $original_url http://exp-service:5050$request_uri;
+               set $original_url http://exp-service:5050$uri;
 
-               proxy_pass http://proxy-service/proxy?to=$original_url;
+               proxy_pass http://proxy-service/proxy?to=$original_url&$args;
 
                proxy_set_header Host $host;
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -60,9 +60,9 @@ http {
           }
           
           location /api {
-               set $original_url http://emf-cloud-service:8081$request_uri;
+               set $original_url http://emf-cloud-service:8081$uri;
 
-               proxy_pass http://proxy-service/proxy?to=$original_url;
+               proxy_pass http://proxy-service/proxy?to=$original_url&$args;
 
                proxy_set_header Host $host;
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
@oralmpa identified an issue with GET requests. In the latest version, the proxy and Nginx were not correctly parsing the query parameters.

The problem was that once the request reached Nginx, it added a new query parameter called "to". This parameter is used by the proxy to determine which route to protect and where to redirect the request.

However, Nginx was incorrectly appending the `"?"` symbol in the redirect URL. If the original URL already contained query parameters (i.e., already had a `"?"`), the additional `"?"` caused the query string to break, rather than merge correctly with the existing parameters.

This behavior has now been fixed — query parameters are merged as expected.

For documentation purposes, the following example illustrates the behavior before and after the fix.

> Before: proxy-service           | 192.168.10.6 - - [27/May/2025 14:08:24] "GET /proxy?to=http://backend:5001/ddm/catalog/list?page=1&perPage=10&sort=created,desc&file_type=xls HTTP/1.0" 200 -

`With two "?" symbols and ignored parameters after the second "?" symbol`

> After: proxy-service           | 192.168.10.6 - - [27/May/2025 14:08:24] "GET /proxy?to=http://backend:5001/ddm/catalog/list&page=1&perPage=10&sort=created,desc&file_type=xls HTTP/1.0" 200 -

`With one "?" symbol and query parameters correctly forwarded`